### PR TITLE
Move landing language selector to footer

### DIFF
--- a/src/components/nav/LanguageMenu.astro
+++ b/src/components/nav/LanguageMenu.astro
@@ -200,21 +200,28 @@ function originRelativeHref(href: string): string {
         outline-offset: 2px;
     }
 
-    :global(.mobile-menu-language.language-menu) {
-        width: 100%;
+    :global(.footer-language-menu.language-menu) {
+        width: fit-content;
+        max-width: 100%;
+        margin-top: 18px;
     }
 
-    :global(.mobile-menu-language.language-menu) .language-menu-trigger {
-        width: 100%;
-        justify-content: space-between;
-        padding: 10px 16px;
-        border-radius: 10px;
+    :global(.footer-language-menu.language-menu) .language-menu-trigger {
+        min-height: 38px;
+        padding: 8px 12px;
+        border-color: var(--nav-border);
+        color: var(--duet-muted);
     }
 
-    :global(.mobile-menu-language.language-menu) .language-menu-panel {
-        position: static;
-        max-height: 240px;
-        margin-top: 6px;
-        box-shadow: none;
+    :global(.footer-language-menu.language-menu) .language-menu-trigger:hover {
+        color: var(--prose-heading);
+    }
+
+    :global(.footer-language-menu.language-menu) .language-menu-panel {
+        right: auto;
+        left: 0;
+        top: auto;
+        bottom: calc(100% + 8px);
+        max-height: min(360px, calc(100vh - 96px));
     }
 </style>

--- a/src/components/nav/LegalNav.astro
+++ b/src/components/nav/LegalNav.astro
@@ -1,8 +1,7 @@
 ---
-import LanguageMenu from "./LanguageMenu.astro"
 import ThemeToggle from "../ui/ThemeToggle.astro";
 import type { Locale } from "../../i18n/locales"
-import { localizedPath, type AlternateLink } from "../../i18n/routing"
+import { localizedPath } from "../../i18n/routing"
 import { t, type Messages } from "../../i18n/messages/schema"
 
 type ActivePage = "terms" | "privacy" | "cookies" | "disclaimer"
@@ -11,10 +10,9 @@ type Props = {
     active?: ActivePage
     locale: Locale
     messages: Messages
-    alternates: AlternateLink[]
 }
 
-const { active, locale, messages, alternates } = Astro.props
+const { active, locale, messages } = Astro.props
 
 const homePath = localizedPath(locale, { kind: "home" })
 const links: Array<{ key: ActivePage | "home"; label: string; href: string }> = [
@@ -80,12 +78,6 @@ const closeMenuLabel = t(messages, "nav.closeMenu")
         </nav>
 
         <div class="flex items-center gap-3">
-            <LanguageMenu
-                locale={locale}
-                messages={messages}
-                alternates={alternates}
-                className="desktop-language-menu"
-            />
             <ThemeToggle ariaLabel={t(messages, "theme.toggle")} />
             <details class="mobile-menu xl:hidden" data-mobile-menu>
                 <summary
@@ -146,12 +138,6 @@ const closeMenuLabel = t(messages, "nav.closeMenu")
                             {link.label}
                         </a>
                     ))}
-                    <LanguageMenu
-                        locale={locale}
-                        messages={messages}
-                        alternates={alternates}
-                        className="mobile-menu-language"
-                    />
                 </nav>
             </details>
         </div>
@@ -377,13 +363,4 @@ const closeMenuLabel = t(messages, "nav.closeMenu")
         background: rgba(0, 0, 0, 0.04);
     }
 
-    :global(.desktop-language-menu) {
-        display: none;
-    }
-
-    @media (min-width: 1280px) {
-        :global(.desktop-language-menu) {
-            display: block;
-        }
-    }
 </style>

--- a/src/components/nav/Nav.astro
+++ b/src/components/nav/Nav.astro
@@ -1,18 +1,16 @@
 ---
-import LanguageMenu from "./LanguageMenu.astro";
 import ThemeToggle from "../ui/ThemeToggle.astro";
 import { AUTH_CHOOSER_URL } from "../../utils/constants";
 import type { Locale } from "../../i18n/locales";
-import { localizedPath, type AlternateLink } from "../../i18n/routing";
+import { localizedPath } from "../../i18n/routing";
 import { t, type Messages } from "../../i18n/messages/schema";
 
 type Props = {
     locale: Locale;
     messages: Messages;
-    alternates: AlternateLink[];
 };
 
-const { locale, messages, alternates } = Astro.props;
+const { locale, messages } = Astro.props;
 
 const homePath = localizedPath(locale, { kind: "home" });
 const anchor = (id: string) => `${homePath}#${id}`;
@@ -66,12 +64,6 @@ const closeMenuLabel = t(messages, "nav.closeMenu");
         </nav>
 
         <div class="flex items-center gap-3">
-            <LanguageMenu
-                locale={locale}
-                messages={messages}
-                alternates={alternates}
-                className="desktop-language-menu"
-            />
             <ThemeToggle ariaLabel={t(messages, "theme.toggle")} />
             <a class="nav-cta" href={AUTH_CHOOSER_URL}>{t(messages, "nav.getStarted")}</a>
 
@@ -117,12 +109,6 @@ const closeMenuLabel = t(messages, "nav.closeMenu");
                     {navLinks.map((link) => (
                         <a class="mobile-menu-link" href={link.href}>{link.label}</a>
                     ))}
-                    <LanguageMenu
-                        locale={locale}
-                        messages={messages}
-                        alternates={alternates}
-                        className="mobile-menu-language"
-                    />
                 </nav>
             </details>
         </div>
@@ -398,13 +384,4 @@ const closeMenuLabel = t(messages, "nav.closeMenu");
         outline-offset: 2px;
     }
 
-    :global(.desktop-language-menu) {
-        display: none;
-    }
-
-    @media (min-width: 1280px) {
-        :global(.desktop-language-menu) {
-            display: block;
-        }
-    }
 </style>

--- a/src/components/sections/Footer.astro
+++ b/src/components/sections/Footer.astro
@@ -1,6 +1,7 @@
 ---
+import LanguageMenu from "../nav/LanguageMenu.astro";
 import type { Locale } from "../../i18n/locales";
-import { localizedPath } from "../../i18n/routing";
+import { localizedPath, type AlternateLink } from "../../i18n/routing";
 import { t, type Messages } from "../../i18n/messages/schema";
 
 type FooterLink = {
@@ -19,9 +20,10 @@ type FooterGroup = {
 type Props = {
     locale: Locale;
     messages: Messages;
+    alternates: AlternateLink[];
 };
 
-const { locale, messages } = Astro.props;
+const { locale, messages, alternates } = Astro.props;
 const year = new Date().getFullYear();
 const homePath = localizedPath(locale, { kind: "home" });
 const anchor = (id: string) => `${homePath}#${id}`;
@@ -124,6 +126,13 @@ const groups: FooterGroup[] = [
                 <p class="footer-tagline mt-5 mb-0 max-w-sm text-pretty">
                     {t(messages, "footer.tagline")}
                 </p>
+
+                <LanguageMenu
+                    locale={locale}
+                    messages={messages}
+                    alternates={alternates}
+                    className="footer-language-menu"
+                />
 
                 <p class="footer-copyright mt-10 mb-0">
                     {t(messages, "footer.copyright", { year })}

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -159,7 +159,7 @@ const extraHeadHtml = [
     ogType="article"
     extraHeadHtml={extraHeadHtml}
 >
-    <Nav locale={locale} messages={messages} alternates={alternates} />
+    <Nav locale={locale} messages={messages} />
 
     <div class="reading-progress" id="reading-progress">
         <div class="reading-progress-bar" id="reading-progress-bar"></div>
@@ -259,7 +259,7 @@ const extraHeadHtml = [
             </footer>
         </article>
     </main>
-    <Footer locale={locale} messages={messages} />
+    <Footer locale={locale} messages={messages} alternates={alternates} />
 </BaseLayout>
 
 <script>

--- a/src/layouts/LegalLayout.astro
+++ b/src/layouts/LegalLayout.astro
@@ -131,7 +131,7 @@ const extraHeadHtml = `${jsonLdScript(pageJsonLd)}\n${jsonLdScript(breadcrumbJso
     robotsDirectives={robotsDirectives}
     extraHeadHtml={extraHeadHtml}
 >
-    <LegalNav active={activeNav} locale={locale} messages={messages} alternates={alternates} />
+    <LegalNav active={activeNav} locale={locale} messages={messages} />
 
     <main class="relative isolate">
         <div class="mx-auto max-w-4xl px-6 pt-28 pb-20 md:px-10">
@@ -146,7 +146,7 @@ const extraHeadHtml = `${jsonLdScript(pageJsonLd)}\n${jsonLdScript(breadcrumbJso
         </div>
     </main>
 
-    <Footer locale={locale} messages={messages} />
+    <Footer locale={locale} messages={messages} alternates={alternates} />
 </BaseLayout>
 
 <style>

--- a/src/pages/[locale]/blog/index.astro
+++ b/src/pages/[locale]/blog/index.astro
@@ -77,7 +77,7 @@ function getIssueNumber(index: number, total: number): string {
     robotsDirectives={robotsDirectives}
     extraHeadHtml={extraHeadHtml}
 >
-    <Nav locale={locale} messages={messages} alternates={alternates} />
+    <Nav locale={locale} messages={messages} />
     <main class="blog-index">
         <header class="blog-header">
             <div class="blog-header-inner">
@@ -206,5 +206,5 @@ function getIssueNumber(index: number, total: number): string {
             )
         }
     </main>
-    <Footer locale={locale} messages={messages} />
+    <Footer locale={locale} messages={messages} alternates={alternates} />
 </BaseLayout>

--- a/src/pages/[locale]/for/[slug].astro
+++ b/src/pages/[locale]/for/[slug].astro
@@ -84,7 +84,7 @@ const extraHeadHtml = [
     robotsDirectives={robotsDirectives}
     extraHeadHtml={extraHeadHtml}
 >
-    <Nav locale={locale} messages={messages} alternates={alternates} />
+    <Nav locale={locale} messages={messages} />
     <main class="relative isolate">
         <HeroBackground />
         <Hero hero={homeSections.hero} heroHeadline={data.heroHeadline} heroSubline={data.heroSubline} heroBadge={data.heroBadge}>
@@ -110,5 +110,5 @@ const extraHeadHtml = [
         <FAQ faq={homeSections.faq} verticalFaqs={data.verticalFaqs} />
     </main>
     <FinalCTA finalCta={homeSections.finalCta} ctaHeadline={data.ctaHeadline} ctaSubline={data.ctaSubline} />
-    <Footer locale={locale} messages={messages} />
+    <Footer locale={locale} messages={messages} alternates={alternates} />
 </BaseLayout>

--- a/src/pages/[locale]/index.astro
+++ b/src/pages/[locale]/index.astro
@@ -114,7 +114,7 @@ const extraHeadHtml = [
     robotsDirectives={robotsDirectives}
     extraHeadHtml={extraHeadHtml}
 >
-    <Nav locale={locale} messages={messages} alternates={alternates} />
+    <Nav locale={locale} messages={messages} />
     <main class="relative isolate">
         <HeroBackground />
         <Hero hero={homeSections.hero}>
@@ -133,5 +133,5 @@ const extraHeadHtml = [
         <FAQ faq={homeSections.faq} />
     </main>
     <FinalCTA finalCta={homeSections.finalCta} />
-    <Footer locale={locale} messages={messages} />
+    <Footer locale={locale} messages={messages} alternates={alternates} />
 </BaseLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -75,7 +75,7 @@ function getIssueNumber(index: number, total: number): string {
     robotsDirectives={robotsDirectives}
     extraHeadHtml={extraHeadHtml}
 >
-    <Nav locale={locale} messages={messages} alternates={alternates} />
+    <Nav locale={locale} messages={messages} />
     <main class="blog-index">
         <header class="blog-header">
             <div class="blog-header-inner">
@@ -206,5 +206,5 @@ function getIssueNumber(index: number, total: number): string {
             )
         }
     </main>
-    <Footer locale={locale} messages={messages} />
+    <Footer locale={locale} messages={messages} alternates={alternates} />
 </BaseLayout>

--- a/src/pages/for/[slug].astro
+++ b/src/pages/for/[slug].astro
@@ -84,7 +84,7 @@ const extraHeadHtml = [
     robotsDirectives={robotsDirectives}
     extraHeadHtml={extraHeadHtml}
 >
-    <Nav locale={locale} messages={messages} alternates={alternates} />
+    <Nav locale={locale} messages={messages} />
     <main class="relative isolate">
         <HeroBackground />
         <Hero hero={homeSections.hero} heroHeadline={data.heroHeadline} heroSubline={data.heroSubline} heroBadge={data.heroBadge}>
@@ -110,5 +110,5 @@ const extraHeadHtml = [
         <FAQ faq={homeSections.faq} verticalFaqs={data.verticalFaqs} />
     </main>
     <FinalCTA finalCta={homeSections.finalCta} ctaHeadline={data.ctaHeadline} ctaSubline={data.ctaSubline} />
-    <Footer locale={locale} messages={messages} />
+    <Footer locale={locale} messages={messages} alternates={alternates} />
 </BaseLayout>

--- a/src/pages/i18n-qa/[pseudoLocale].astro
+++ b/src/pages/i18n-qa/[pseudoLocale].astro
@@ -49,7 +49,7 @@ const alternates = englishOnlyAlternates(Astro.site, { kind: "home" });
     alternates={alternates}
     robotsDirectives="noindex,noarchive"
 >
-    <Nav locale={routeLocale} messages={messages} alternates={alternates} />
+    <Nav locale={routeLocale} messages={messages} />
     <main class="relative isolate">
         <HeroBackground />
         <Hero hero={homeSections.hero}>
@@ -68,5 +68,5 @@ const alternates = englishOnlyAlternates(Astro.site, { kind: "home" });
         <FAQ faq={homeSections.faq} />
     </main>
     <FinalCTA finalCta={homeSections.finalCta} />
-    <Footer locale={routeLocale} messages={messages} />
+    <Footer locale={routeLocale} messages={messages} alternates={alternates} />
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -108,7 +108,7 @@ const extraHeadHtml = [
     robotsDirectives={robotsDirectives}
     extraHeadHtml={extraHeadHtml}
 >
-    <Nav locale={locale} messages={messages} alternates={alternates} />
+    <Nav locale={locale} messages={messages} />
     <main class="relative isolate">
         <HeroBackground />
         <Hero hero={homeSections.hero}>
@@ -127,5 +127,5 @@ const extraHeadHtml = [
         <FAQ faq={homeSections.faq} />
     </main>
     <FinalCTA finalCta={homeSections.finalCta} />
-    <Footer locale={locale} messages={messages} />
+    <Footer locale={locale} messages={messages} alternates={alternates} />
 </BaseLayout>


### PR DESCRIPTION
## Summary
- Move the landing language selector out of the desktop and mobile nav
- Render the selector in the footer while preserving locale alternate links
- Remove now-unused nav language selector styling

## Test Plan
- pnpm check
- pnpm i18n:verify
- pnpm i18n:scan-source
- pnpm i18n:build
- pnpm i18n:verify:dist
- git diff --check